### PR TITLE
Remove compression mode in PNG optimizer

### DIFF
--- a/buildSrc/src/main/kotlin/PngOptimizingTransformer.kt
+++ b/buildSrc/src/main/kotlin/PngOptimizingTransformer.kt
@@ -82,7 +82,6 @@ class PngOptimizingTransformer(
 
             val writer = ImageIO.getImageWritersByFormatName("png").next()
             val param = writer.defaultWriteParam
-            param.compressionMode = ImageWriteParam.MODE_DISABLED
 
             writer.output = imageOutputStream
             writer.write(null, IIOImage(scaledImage, null, null), param)


### PR DESCRIPTION
Not all JVM implementations support all modes and it's useless anyway since the images are further processed afterward. We can just use whatever the default is here.