### PR TITLE
Change icon search order

### DIFF
--- a/icons/src/main/kotlin/com/almightyalpaca/jetbrains/plugins/discord/icons/matcher/Matcher.kt
+++ b/icons/src/main/kotlin/com/almightyalpaca/jetbrains/plugins/discord/icons/matcher/Matcher.kt
@@ -48,10 +48,10 @@ sealed class Matcher {
     }
 
     enum class Target(val id: String) {
-        EXTENSION("extension"),
+        PATH("path"),
         NAME("name"),
         BASENAME("basename"),
-        PATH("path");
+        EXTENSION("extension");
         // CONTENT("content") // TODO: implement content/magic byte matching
         // EDITOR("editor") // TODO: implement matching the editor type
 


### PR DESCRIPTION
This fixes the issue with for example `.toml` being chosen over `Cargo.toml`