### PR TITLE
Change folder name inside plugin .zip

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -73,6 +73,8 @@ val isCI by lazy { System.getenv("CI") != null }
 intellij {
     val versionIde: String by project
 
+    pluginName(rootProject.name)
+
     version.set(versionIde)
 
     downloadSources.set(!isCI)


### PR DESCRIPTION
This prevents conflicts with other plugins (e.g. Perl)