### PR TITLE
Fix rich presence timing issue

### DIFF
--- a/plugin/src/main/kotlin/com/almightyalpaca/jetbrains/plugins/discord/plugin/rpc/RpcService.kt
+++ b/plugin/src/main/kotlin/com/almightyalpaca/jetbrains/plugins/discord/plugin/rpc/RpcService.kt
@@ -54,7 +54,7 @@ class RpcService : DisposableCoroutineScope {
     private val mutex = Mutex()
 
     private fun checkConnected(): Job = launch {
-        delay(20_000)
+        delay(120_000)
 
         mutex.withLock {
             DiscordPlugin.LOG.debug("Checking for running rpc connection")


### PR DESCRIPTION
I had some investigation, even this plugin tries restart every 20 seconds, [discord-rpc reconnection time](https://github.com/discord/discord-rpc/blob/master/src/discord_rpc.cpp#L73) is 60 seconds.
Therfore, this is a minimal changes to make discord-rpc properly work.

Fixes #223 